### PR TITLE
Add options for start service argument passing

### DIFF
--- a/src/bin/shawl-child.rs
+++ b/src/bin/shawl-child.rs
@@ -15,6 +15,10 @@ struct Cli {
     /// Exit immediately with this code
     #[structopt(long)]
     exit: Option<i32>,
+
+    /// Test option, prints an extra line to stdout if received
+    #[structopt(long)]
+    test: bool,
 }
 
 fn prepare_logging() -> Result<(), Box<dyn std::error::Error>> {
@@ -54,6 +58,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     println!("shawl-child message on stdout");
     eprintln!("shawl-child message on stderr");
+
+    if cli.test {
+        println!("shawl-child test option received");
+    }
 
     if let Some(code) = cli.exit {
         std::process::exit(code);

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -163,5 +163,14 @@ speculate::speculate! {
             let log = std::fs::read_to_string(log_file()).unwrap();
             assert!(!log.contains("shawl-child has started"));
         }
+
+        it "can pass arguments through successfully" {
+            run_shawl(&["add", "--name", "shawl", "--pass-start-args", "--", &child()]);
+            run_cmd(&["sc", "start", "shawl", "--test"]);
+            run_cmd(&["sc", "stop", "shawl"]);
+
+            let log = std::fs::read_to_string(log_file()).unwrap();
+            assert!(log.contains("[shawl] stdout: \"shawl-child test option received\""));
+        }
     }
 }


### PR DESCRIPTION
This adds the option `--pass-start-args` to shawl so that arguments given on service start can be passed into the managed executable.

So for example, we can create a new service like this:

```sh
shawl add --name myservice --pass-start-args -- C:\Path\to\file.exe
```

Now when starting the service like this:
```sh
sc start myservice extra
```

The argument `extra` is also passed to `file.exe`.

Tests have been written as well.